### PR TITLE
Disable CI/CD Runs Automatically

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -115,7 +115,7 @@ jobs:
       - name: Down Infrastructure
         if: always()  # Ensure this step runs even if previous steps fail
         run: |
-          azd down --force --no-prompt
+          azd down --force --purge --no-prompt
         shell: pwsh
         env:
           AZURE_ENV_NAME: ${{ secrets.AZURE_ENV_NAME }}


### PR DESCRIPTION
## Purpose
* GitHub Actions が走らないように設定
* `azd down --force --purge` が必ず走るようにした

## Does this introduce a breaking change?
```
[ ] Yes
[x] No
```
