### PR TITLE
Add `TRY_CONVERT(uniqueidentifier, …)` safeguards to ARC data INSERT statements

### DIFF
--- a/scripts/upload_arc_data_to_azure_sql.py
+++ b/scripts/upload_arc_data_to_azure_sql.py
@@ -166,7 +166,7 @@ ELSE
 		resource_id,name,subscription_id,resource_group,location,vm_size,os_type,os_name,os_version,
 		provisioning_state,priority,time_created,power_state,admin_username,server_type_tag,tags_json,identity_principal_id
 	) VALUES (
-		?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?
+		?, ?, TRY_CONVERT(uniqueidentifier, ?), ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, TRY_CONVERT(uniqueidentifier, ?)
 	);
 """,
 			row.get("id"),  # for UPDATE match
@@ -227,7 +227,7 @@ IF EXISTS (SELECT 1 FROM dbo.network_interfaces WHERE resource_id = ?)
 ELSE
 	INSERT INTO dbo.network_interfaces (
 		resource_id,name,subscription_id,resource_group,location,mac_address,private_ip,allocation_method,accelerated,primary_flag,vm_resource_id
-	) VALUES (?,?,?,?,?,?,?,?,?,?,?);
+	) VALUES (?, ?, TRY_CONVERT(uniqueidentifier, ?), ?, ?, ?, ?, ?, ?, ?, ?);
 """,
 			row.get("id"),
 			row.get("name"),


### PR DESCRIPTION
### **Summary**

This PR updates `upload_arc_data_to_azure_sql.py` to prevent SQL Server `uniqueidentifier` conversion errors during ARC data inserts.
The INSERT paths now match the existing UPDATE logic by wrapping GUID-typed fields in `TRY_CONVERT(uniqueidentifier, …)`.

### **Changes**

* Updated ARC resource INSERT statements to apply:

  * `TRY_CONVERT(uniqueidentifier, ?)` to `subscription_id`
  * `TRY_CONVERT(uniqueidentifier, ?)` to `identity_principal_id`
* Updated network interface INSERT statement to apply:

  * `TRY_CONVERT(uniqueidentifier, ?)` to `subscription_id`
* Ensures empty or malformed GUID strings no longer cause SQL Server to fail the bulk load.

### **Validation**

* Ran `azd up` and tested the sample queries